### PR TITLE
fix EmbeddedChannel error in link.mock

### DIFF
--- a/src/link/mock.clj
+++ b/src/link/mock.clj
@@ -1,6 +1,6 @@
 (ns link.mock
   (:require [link.core :refer :all])
-  (:import (io.netty.channel DefaultChannelPromise)
+  (:import (io.netty.channel DefaultChannelPromise ChannelHandler)
            (io.netty.channel.embedded EmbeddedChannel)))
 
 (deftype MockChannel [chid local-addr remote-addr msgs stopped?]
@@ -11,7 +11,7 @@
   (send!* [this msg cb]
     (swap! msgs conj msg)
     (when cb
-      (let [promise (DefaultChannelPromise. (EmbeddedChannel.))]
+      (let [promise (DefaultChannelPromise. (EmbeddedChannel. (make-array ChannelHandler 0)))]
         (.setSuccess promise)
         (cb promise))))
   (close! [this]


### PR DESCRIPTION
Sorry, [EmbeddedChannel](https://github.com/netty/netty/blob/4.0/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java#L77) in Netty 4.0.37.Final doesn't not have any empty arguments constructor... [This constructor](https://github.com/netty/netty/blob/4.1/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java#L80) only exists in Netty 4.1.x 