### PR TITLE
Use Netty ByteBuf for byte-block

### DIFF
--- a/src/link/codec.clj
+++ b/src/link/codec.clj
@@ -1,6 +1,5 @@
 (ns link.codec
   (:refer-clojure :exclude [byte float double])
-  (:import [java.nio ByteBuffer])
   (:import [java.util List])
   (:import [io.netty.buffer
             ByteBuf])
@@ -98,25 +97,22 @@
                     (String. sbytes encoding))))))))
 
 (defcodec byte-block
-  (encoder [options ^ByteBuffer data ^ByteBuf buffer]
+  (encoder [options ^ByteBuf data ^ByteBuf buffer]
            (let [{prefix :prefix encode-length-fn :encode-length-fn} options
                  encode-length-fn (or encode-length-fn identity)
-                 byte-length (if (nil? data) 0 (.remaining data))
+                 byte-length (if (nil? data) 0 (.readableBytes data))
                  encoded-length (encode-length-fn byte-length)]
              ((:encoder prefix) encoded-length buffer)
              (if-not (nil? data)
-               (.writeBytes buffer ^ByteBuffer data))
+               (.writeBytes buffer ^ByteBuf data))
              buffer))
   (decoder [options ^ByteBuf buffer]
            (let [{prefix :prefix decode-length-fn :decode-length-fn} options
                  decode-length-fn (or decode-length-fn identity)
                  byte-length (decode-length-fn ((:decoder prefix) buffer))]
-             (if-not (or (nil? byte-length)
-                         (> byte-length (.readableBytes buffer)))
-               (let [local-buffer (ByteBuffer/allocate byte-length)]
-                 (.readBytes buffer ^ByteBuffer local-buffer)
-                 (.rewind local-buffer)
-                 local-buffer)))))
+             (when-not (or (nil? byte-length)
+                           (> byte-length (.readableBytes buffer)))
+               (.readRetainedSlice buffer byte-length)))))
 
 (def ^{:private true} reversed-map
   (memoize

--- a/src/link/codec.clj
+++ b/src/link/codec.clj
@@ -103,8 +103,9 @@
                  byte-length (if (nil? data) 0 (.readableBytes data))
                  encoded-length (encode-length-fn byte-length)]
              ((:encoder prefix) encoded-length buffer)
-             (if-not (nil? data)
-               (.writeBytes buffer ^ByteBuf data))
+             (when-not (nil? data)
+               (.writeBytes buffer ^ByteBuf data)
+               (.release ^ByteBuf data))
              buffer))
   (decoder [options ^ByteBuf buffer]
            (let [{prefix :prefix decode-length-fn :decode-length-fn} options

--- a/test/link/codec_test.clj
+++ b/test/link/codec_test.clj
@@ -46,3 +46,13 @@
 
 
     (is (nil? (decode* codec buffer)))))
+
+(deftest test-byte-block
+  (let [buffer (Unpooled/buffer)
+        bytes (Unpooled/wrappedBuffer (.getBytes "Hello World" "UTF-8"))
+        codec (byte-block :prefix (uint16))]
+    (encode* codec bytes buffer)
+    (let [decoded-buffer (decode* codec buffer)
+          bytes (byte-array (.readableBytes decoded-buffer))]
+      (.readBytes decoded-buffer bytes)
+      (is (= "Hello World" (String. bytes "UTF-8"))))))


### PR DESCRIPTION
So we can use slice to avoid copy to JVM byte-buffer