### PR TITLE
修复一处 NPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ target
 .lein-env
 .nrepl-port
 .lein*
+.idea/
+*.iml

--- a/src/link/http.clj
+++ b/src/link/http.clj
@@ -139,9 +139,10 @@
 (defn create-http-handler-from-ring [ring-fn debug]
   (create-handler
    (on-message [ch msg]
-               (let [req (ring-request ch msg)
-                     resp (or (ring-fn req) {})]
-                 (http-handle resp ch req)))
+               (when (valid? ch)
+                 (let [req  (ring-request ch msg)
+                       resp (or (ring-fn req) {})]
+                   (http-handle resp ch req))))
 
    (on-error [ch exc]
              (logging/warn exc "Uncaught exception")


### PR DESCRIPTION
NioSocketChannel 在非 active 时，remote-addr 会返回 nil，从而在 link.http/ring-request 下会抛 NPE，异常如下：
```
2017-03-16 19:05:00,489 WARN  link.http: Uncaught exception
java.lang.NullPointerException
        at link.http$ring_request.invokeStatic(http.clj:48)
        at link.http$ring_request.invoke(http.clj:43)
        at link.http$create_http_handler_from_ring$fn__7442.invoke(http.clj:142)
        at link.http$create_http_handler_from_ring$fn__7463.invoke(http.clj:140)
        at link.http.proxy$io.netty.channel.SimpleChannelInboundHandler$ff19274a.channelRead0(Unknown Source)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
        at link.http.proxy$io.netty.channel.SimpleChannelInboundHandler$ff19274a.channelRead(Unknown Source)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:372)
        at io.netty.channel.AbstractChannelHandlerContext.access$600(AbstractChannelHandlerContext.java:38)
        at io.netty.channel.AbstractChannelHandlerContext$7.run(AbstractChannelHandlerContext.java:363)
        at io.netty.util.concurrent.DefaultEventExecutor.run(DefaultEventExecutor.java:66)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:873)
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144)
        at java.lang.Thread.run(Thread.java:745)

```

所以考虑在收到消息的时候检查 channel，如果非 valid 就不再处理请求。