### PR TITLE
support channel option with class?

### DIFF
--- a/src/link/tcp.clj
+++ b/src/link/tcp.clj
@@ -120,7 +120,7 @@
       (.group worker-group)
       (.channel NioSocketChannel)
       (.handler channel-initializer))
-    (doseq [op options]
+    (doseq [op (into [] options)]
       (let [op (flatten op)]
         (.option bootstrap (apply to-channel-option (butlast op)) (last op))))
 


### PR DESCRIPTION
Can we consider to support channel option like this? 
```clojure
  {:so-reuseaddr                 true
   :tcp-fastopen                 [EpollChannelOption 128]}
```
`EpollChannelOption` is not under `ChannelOption` if we don't pass class, there will be a warning says "Unknown channel option.....".
