### PR TITLE
use long channel id as default channel id

### DIFF
--- a/src/link/core.clj
+++ b/src/link/core.clj
@@ -14,7 +14,7 @@
 
 (defprotocol LinkMessageChannel
   (id [this])
-  (long-id [this])
+  (short-id [this])
   (send! [this msg])
   (send!* [this msg cb])
   (valid? [this])
@@ -30,17 +30,17 @@
        ":" (.getPort addr)))
 
 (defn channel-id [^Channel ch]
-  (.asShortText ^ChannelId (.id ch)))
-
-(defn long-channel-id [^Channel ch]
   (.asLongText ^ChannelId (.id ch)))
+
+(defn short-channel-id [^Channel ch]
+  (.asShortText ^ChannelId (.id ch)))
 
 (deftype ClientSocketChannel [ch-agent factory-fn stopped]
   LinkMessageChannel
   (id [this]
     (channel-id @ch-agent))
-  (long-id [this]
-    (long-channel-id @ch-agent))
+  (short-id [this]
+    (short-channel-id @ch-agent))
   (send! [this msg]
     (send!* this msg nil))
   (send!* [this msg cb]
@@ -77,8 +77,8 @@
   NioSocketChannel
   (id [this]
     (channel-id this))
-  (long-id [this]
-    (long-channel-id this))
+  (short-id [this]
+    (short-channel-id this))
   (send! [this msg]
     (.writeAndFlush this msg (.voidPromise this)))
   (send!* [this msg cb]

--- a/src/link/mock.clj
+++ b/src/link/mock.clj
@@ -5,7 +5,7 @@
 (deftype MockChannel [chid local-addr remote-addr msgs stopped?]
   LinkMessageChannel
   (id [this] chid)
-  (long-id [this] (str "long-" chid))
+  (short-id [this] (str "short-" chid))
   (send! [this msg]
     (swap! msgs conj msg))
   (send!* [this msg cb]


### PR DESCRIPTION
as discussed at [here](https://github.com/sunng87/link/pull/38)

Things to think twitce is that long channel id is more verbose and take 52 bytes more memory per channel. And short id usually is safe. Only for a server holding a lot of concurrent connections and most of them is not stable (like reconnect frequently), the short id may not appropriate.